### PR TITLE
imp(all): Add Nix setup for simple dev environment

### DIFF
--- a/.github/workflows/easytk_tests.yml
+++ b/.github/workflows/easytk_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.12']
 
     steps:

--- a/.github/workflows/easytk_tests.yml
+++ b/.github/workflows/easytk_tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.12']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/easytk_tests.yml
+++ b/.github/workflows/easytk_tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Release first working version
+
+- Release full working version
+- Add Nix flake 
 - Add widgets:
   - `EasyFrame`
   - `EasyLabelFrame`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A simple API wrapper to create functional `tkinter` GUIs using only a few lines.
 
-![Tests](https://github.com/MalteHerrmann/easy-toolkit/actions/workflows/easytk_tests.yml/badge.svg)
+Since this is only using `tkinter`, which comes built-in with many Python installations,
+it can be run from within different environments that may restrict the use of other GUI libraries,
+e.g. within the Python REPL of software like [Blender](https://www.blender.org/).
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ import easytk
 
 true_or_false = easytk.ask_yes_no("Pose a question here.")
 ```
+
+## Dev Environment
+
+You can access the dev environment using [Nix flakes](https://nixos.wiki/wiki/Flakes):
+
+```bash
+nix develop
+```
+
+This will install the dependencies and open a shell with the necessary environment variables set.

--- a/examples/example1.py
+++ b/examples/example1.py
@@ -6,6 +6,10 @@ using the easytk package.
 # ------------------------------
 # Imports
 #
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 import easytk
 
 
@@ -18,7 +22,7 @@ def main():
     """
     # Create the main window
     window = easytk.Window("Selection")
-    window.config(selection_text="Yep. Do it.")
+    window.config(selection_text="Return filename.")
     window.add_file_dialog("Test", default_value="Default", filetypes=[("Python files", "*.py")])
     returned_values = window.show()
 

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -6,6 +6,10 @@ create a user interface using the easytk package.
 # ------------------------------
 # Imports
 #
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 import easytk
 
 

--- a/examples/example3.py
+++ b/examples/example3.py
@@ -9,6 +9,10 @@ button to return the selected filename or a `False` button.
 # ------------------------------
 # Imports
 #
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 import easytk
 
 

--- a/examples/example4.py
+++ b/examples/example4.py
@@ -9,6 +9,10 @@ button to return the selected filename or a `False` button.
 # ------------------------------
 # Imports
 #
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 import easytk
 
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733759999,
+        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,36 @@
+{
+  description = "Python development environment with pytest and tkinter";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        
+        pythonEnv = pkgs.python3.withPackages (ps: with ps; [
+          pytest
+          tkinter
+          # Add any other Python packages you need here
+        ]);
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            pythonEnv
+            # Additional development tools
+            black    # Python formatter
+            ruff     # Fast Python linter
+            git
+          ];
+
+          shellHook = ''
+            echo "Python development environment loaded with pytest and tkinter"
+            echo "Python version: $(python --version)"
+          '';
+        };
+      });
+}

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ CLASSIFIERS = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Software Development :: Libraries"
 ]
 

--- a/tests/test_return_widgets.py
+++ b/tests/test_return_widgets.py
@@ -5,6 +5,10 @@ Unit-testing module for the `easytk` return widgets.
 # --------------------
 # Imports
 #
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 import easytk
 
 


### PR DESCRIPTION
This PR adds a Nix flake setup to the repository.
This enables to enter an easily reproducible dev environment by running:

```bash
nix develop
```

Upon the first execution, Nix will install the required dependencies. Once done, the command will enter the terminal where e.g. tests can be run with:

```bash
pytest
```